### PR TITLE
Add netCDF C libraries to LIBS

### DIFF
--- a/templates/osx-gcc10.mk
+++ b/templates/osx-gcc10.mk
@@ -142,6 +142,8 @@ LDFLAGS_COVERAGE :=
 LIBS =
 # NetCDF library flags
 LIBS += $(shell nf-config --flibs)
+# netCDF C library flags, in case installed in a separate directory
+LIBS += $(shell nc-config --libs)
 
 # Get compile flags based on target macros.
 ifdef REPRO


### PR DESCRIPTION
This patch adds the netCDF C libraries alongside the netCDF Fortran libraries in the `LIBS` variable.

Although `nf-config --libs` normally provides the necessary flags for both C and Fortran bindings, these tools may report incorrect information if they are installed in separate directores (as in the current incarnation of Homebrew).

This change will produce redundant flags for most people (which causes no harm) but will resolve issues for separated C and Fortran library installations.