### PR TITLE
Add templates for GCC 10 compilers

### DIFF
--- a/templates/ncrc-gnu8.mk
+++ b/templates/ncrc-gnu8.mk
@@ -84,8 +84,6 @@ FPPFLAGS += $(shell nf-config --fflags)
 
 # Base set of Fortran compiler flags
 FFLAGS := -fcray-pointer -fdefault-real-8 -fdefault-double-8 -Waliasing -ffree-line-length-none -fno-range-check
-# GCC 10 legacy support
-FFLAGS += -fallow-invalid-boz -fallow-argument-mismatch
 
 # Flags based on perforance target (production (OPT), reproduction (REPRO), or debug (DEBUG)
 FFLAGS_OPT = -O2 -fno-expensive-optimizations


### PR DESCRIPTION
This patch modifies the NCRC GCC template file to support the GCC 10 compiler, enabling legacy support for argument mismatch (for MPI calls) and BOZ-literals in FMS.  This reflects upcoming updates to the NCRC software stack.

These flags are unsupported in older GCC compilers (=<9) so this template will no longer work with those compilers.  To support those older compilers, the old template has been moved to `ncrc-gcc8.mk`.